### PR TITLE
Corrected the model event, deleting not deleted.

### DIFF
--- a/src/CascadeDeletes.php
+++ b/src/CascadeDeletes.php
@@ -38,7 +38,7 @@ trait CascadeDeletes
      */
     protected static function registerDeletedHandler()
     {
-        static::deleted(function ($model) {
+        static::deleting(function ($model) {
             $action = self::wasSoftDeleted($model) ? 'delete' : 'forceDelete';
 
             foreach ($model->deletesWith() as $relation) {


### PR DESCRIPTION
The correct event is deleting, so that related records can be deleted before attempting to delete the parent record. This is a problem for databases with foreign key constraints.
